### PR TITLE
Use upstream bit.hpp to fix build issue with gcc5.

### DIFF
--- a/nall/bit.hpp
+++ b/nall/bit.hpp
@@ -1,51 +1,88 @@
 #ifndef NALL_BIT_HPP
 #define NALL_BIT_HPP
 
+#include <nall/stdint.hpp>
+
 namespace nall {
-  template<int bits> constexpr inline unsigned uclamp(const unsigned x) {
-    enum { y = (1U << (bits - 1)) + ((1U << (bits - 1)) - 1) };
-    return y + ((x - y) & -(x < y));  //min(x, y);
+
+template<unsigned bits> inline uintmax_t uclamp(const uintmax_t x) {
+  enum : uintmax_t { b = 1ull << (bits - 1), y = b * 2 - 1 };
+  return y + ((x - y) & -(x < y));  //min(x, y);
+}
+
+template<unsigned bits> inline uintmax_t uclip(const uintmax_t x) {
+  enum : uintmax_t { b = 1ull << (bits - 1), m = b * 2 - 1 };
+  return (x & m);
+}
+
+template<unsigned bits> inline intmax_t sclamp(const intmax_t x) {
+  enum : intmax_t { b = 1ull << (bits - 1), m = b - 1 };
+  return (x > m) ? m : (x < -b) ? -b : x;
+}
+
+template<unsigned bits> inline intmax_t sclip(const intmax_t x) {
+  enum : uintmax_t { b = 1ull << (bits - 1), m = b * 2 - 1 };
+  return ((x & m) ^ b) - b;
+}
+
+namespace bit {
+  constexpr inline uintmax_t mask(const char* s, uintmax_t sum = 0) {
+    return (
+      *s == '0' || *s == '1' ? mask(s + 1, (sum << 1) | 1) :
+      *s == ' ' || *s == '_' ? mask(s + 1, sum) :
+      *s ? mask(s + 1, sum << 1) :
+      sum
+    );
   }
 
-  template<int bits> constexpr inline unsigned uclip(const unsigned x) {
-    enum { m = (1U << (bits - 1)) + ((1U << (bits - 1)) - 1) };
-    return (x & m);
+  constexpr inline uintmax_t test(const char* s, uintmax_t sum = 0) {
+    return (
+      *s == '0' || *s == '1' ? test(s + 1, (sum << 1) | (*s - '0')) :
+      *s == ' ' || *s == '_' ? test(s + 1, sum) :
+      *s ? test(s + 1, sum << 1) :
+      sum
+    );
   }
 
-  template<int bits> constexpr inline signed sclamp(const signed x) {
-    enum { b = 1U << (bits - 1), m = (1U << (bits - 1)) - 1 };
-    return (x > m) ? m : (x < -b) ? -b : x;
+  //lowest(0b1110) == 0b0010
+  constexpr inline uintmax_t lowest(const uintmax_t x) {
+    return x & -x;
   }
 
-  template<int bits> constexpr inline signed sclip(const signed x) {
-    enum { b = 1U << (bits - 1), m = (1U << bits) - 1 };
-    return ((x & m) ^ b) - b;
+  //clear_lowest(0b1110) == 0b1100
+  constexpr inline uintmax_t clear_lowest(const uintmax_t x) {
+    return x & (x - 1);
   }
 
-  namespace bit {
-    //lowest(0b1110) == 0b0010
-    template<typename T> constexpr inline T lowest(const T x) {
-      return x & -x;
-    }
-
-    //clear_lowest(0b1110) == 0b1100
-    template<typename T> constexpr inline T clear_lowest(const T x) {
-      return x & (x - 1);
-    }
-
-    //set_lowest(0b0101) == 0b0111
-    template<typename T> constexpr inline T set_lowest(const T x) {
-      return x | (x + 1);
-    }
-
-    //round up to next highest single bit:
-    //round(15) == 16, round(16) == 16, round(17) == 32
-    inline unsigned round(unsigned x) {
-      if((x & (x - 1)) == 0) return x;
-      while(x & (x - 1)) x &= x - 1;
-      return x << 1;
-    }
+  //set_lowest(0b0101) == 0b0111
+  constexpr inline uintmax_t set_lowest(const uintmax_t x) {
+    return x | (x + 1);
   }
+
+  //count number of bits set in a byte
+  inline unsigned count(uintmax_t x) {
+    unsigned count = 0;
+    do count += x & 1; while(x >>= 1);
+    return count;
+  }
+
+  //return index of the first bit set (or zero of no bits are set)
+  //first(0b1000) == 3
+  inline unsigned first(uintmax_t x) {
+    unsigned first = 0;
+    while(x) { if(x & 1) break; x >>= 1; first++; }
+    return first;
+  }
+
+  //round up to next highest single bit:
+  //round(15) == 16, round(16) == 16, round(17) == 32
+  inline uintmax_t round(uintmax_t x) {
+    if((x & (x - 1)) == 0) return x;
+    while(x & (x - 1)) x &= x - 1;
+    return x << 1;
+  }
+}
+
 }
 
 #endif


### PR DESCRIPTION
It seems the build issues with gcc5 was fixed in upstream higan, so I grabbed their bit.hpp and replaced the one in bnes-libretro with it. It now builds and I was able to start and play Zelda as a result.

Source: https://gitlab.com/higan/higan/blob/10e2a6d497374f815c83b10ad7b223ed6b4d659e/nall/bit.hpp
Fixes https://github.com/libretro/bnes-libretro/issues/7.