### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ c := $(CC) -std=gnu99
 cpp := $(CXX) -std=gnu++0x
 flags := $(opt) -fomit-frame-pointer -fno-tree-vectorize -I. $(fpic)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	flags += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 compile = \
   $(strip \
     $(if $(filter %.c,$<), \

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -122,7 +122,10 @@ static libRETRO libretro;
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "bnes";
-   info->library_version = "v083";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "v083" GIT_VERSION;
    info->need_fullpath = false;
    info->block_extract = false;
    info->valid_extensions = "nes";


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.