### PR TITLE
libretro: Use platform=unix instead platform=x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ compile = \
 libnes_objects := $(patsubst %,obj/%.o,$(objects))
 
 $(TARGET): $(libnes_objects)
-ifeq ($(platform),x)
+ifeq ($(platform),unix)
 	$(cpp) -o $@ -shared $(libnes_objects) -Wl,--no-undefined -Wl,--version-script=link.T
 else ifeq ($(platform),win)
 	$(cpp) -o $@ -shared $(libnes_objects) -Wl,--no-undefined -static-libgcc -static-libstdc++ -Wl,--version-script=link.T

--- a/nall/Makefile
+++ b/nall/Makefile
@@ -23,7 +23,7 @@ ifeq ($(platform),)
   else ifneq ($(findstring NT,$(uname)),)
     platform := win
   else
-    platform := x
+    platform := unix
   endif
 endif
 


### PR DESCRIPTION
We recently ran into an *interesting* issue with platform autodetection (https://github.com/kodi-game/game.libretro.2048/pull/3).

This changes allows to build bnes with platform=unix, like the other cores.