### PR TITLE
Silence two -Wswitch_bool warnings

### DIFF
--- a/nes/cartridge/board/nes-fxrom.cpp
+++ b/nes/cartridge/board/nes-fxrom.cpp
@@ -34,7 +34,8 @@ void prg_write(unsigned addr, uint8 data) {
 }
 
 unsigned ciram_addr(unsigned addr) const {
-  switch(mirror) {
+  unsigned mirror_type = mirror;
+  switch(mirror_type) {
   case 0: return ((addr & 0x0400) >> 0) | (addr & 0x03ff);  //vertical mirroring
   case 1: return ((addr & 0x0800) >> 1) | (addr & 0x03ff);  //horizontal mirroring
   }

--- a/nes/cartridge/board/nes-pxrom.cpp
+++ b/nes/cartridge/board/nes-pxrom.cpp
@@ -40,7 +40,8 @@ void prg_write(unsigned addr, uint8 data) {
 }
 
 unsigned ciram_addr(unsigned addr) const {
-  switch(mirror) {
+  unsigned mirror_type = mirror;
+  switch(mirror_type) {
   case 0: return ((addr & 0x0400) >> 0) | (addr & 0x03ff);  //vertical mirroring
   case 1: return ((addr & 0x0800) >> 1) | (addr & 0x03ff);  //horizontal mirroring
   }


### PR DESCRIPTION
Silences the following two warnings.
```
In file included from nes/cartridge/board/board.cpp:9:0,
                 from nes/cartridge/cartridge.cpp:7:
nes/cartridge/board/nes-fxrom.cpp: In member function ‘unsigned int NES::NES_FxROM::ciram_addr(unsigned int) const’:
nes/cartridge/board/nes-fxrom.cpp:37:16: warning: switch condition has type bool [-Wswitch-bool]
   switch(mirror) {
                ^
In file included from nes/cartridge/board/board.cpp:12:0,
                 from nes/cartridge/cartridge.cpp:7:
nes/cartridge/board/nes-pxrom.cpp: In member function ‘unsigned int NES::NES_PxROM::ciram_addr(unsigned int) const’:
nes/cartridge/board/nes-pxrom.cpp:43:16: warning: switch condition has type bool [-Wswitch-bool]
   switch(mirror) {
                ^
```